### PR TITLE
Allow to specify external word- and character embeddings.

### DIFF
--- a/barchybrid/src/parser.py
+++ b/barchybrid/src/parser.py
@@ -226,7 +226,10 @@ each")
         help="MLP hidden layer dimensions", default=100)
     group.add_option("--mlp-hidden2-dims", type="int", metavar="INTEGER",
         help="MLP second hidden layer dimensions", default=0)
-    group.add_option("--ext-emb-file", metavar="FILE", help="External embeddings")
+    group.add_option("--ext-word-emb-file", metavar="FILE",
+                     help="External word embeddings")
+    group.add_option("--ext-char-emb-file", metavar="FILE",
+                     help="External character embeddings")
     group.add_option("--ext-emb-dir", metavar="PATH", help='Directory containing external embeddings')
     group.add_option("--max-ext-emb", type="int", metavar="INTEGER",
         help='Maximum number of external embeddings to load', default=-1)

--- a/barchybrid/src/utils.py
+++ b/barchybrid/src/utils.py
@@ -489,36 +489,41 @@ def extract_embeddings_from_file(filename, words=None, max_emb=-1, filtered_file
 
     return embeddings
 
-def get_external_embeddings(options,lang=None,words=None,chars=False):
+
+def get_external_embeddings(options, emb_file=None, emb_dir=None,
+                            lang=None, words=None, chars=False):
 
     external_embedding = {}
 
-    if options.ext_emb_file:
+    if emb_file:
+        external_embedding = extract_embeddings_from_file(
+            emb_file, words, options.max_ext_emb)
 
-        external_embedding = extract_embeddings_from_file(options.ext_emb_file,
-            words, options.max_ext_emb)
-
-    elif options.ext_emb_dir:
-
+    elif emb_dir:
         if not lang:
             raise Exception("No language specified for external embeddings")
         else:
-
             lang_iso_dict = load_lang_iso_dict(options.json_isos)
-            emb_dir = os.path.join(options.ext_emb_dir,lang)
+            emb_dir = os.path.join(emb_dir, lang)
 
             if chars:
-                emb_file = os.path.join(emb_dir,lang_iso_dict[lang] + '.vectors.chars.txt')
+                emb_file = os.path.join(
+                    emb_dir,lang_iso_dict[lang] + '.vectors.chars.txt')
             else:
                 if options.shared_task or options.unfiltered_vecs:
-                    emb_file = os.path.join(emb_dir,lang_iso_dict[lang] + '.vectors.txt')
+                    emb_file = os.path.join(
+                        emb_dir,lang_iso_dict[lang] + '.vectors.txt')
                 else:
-                    emb_file = os.path.join(emb_dir,lang_iso_dict[lang] + '.vectors.filtered.txt')
+                    emb_file = os.path.join(
+                        emb_dir,lang_iso_dict[lang] + '.vectors.filtered.txt')
 
             if os.path.exists(emb_file):
-                external_embedding.update(extract_embeddings_from_file(emb_file, words, options.max_ext_emb))
+                embeddings = extract_embeddings_from_file(
+                    emb_file, words, options.max_ext_emb)
+                external_embedding.update(embeddings)
             else:
-                print "Warning: %s does not exist, proceeding without"%(emb_file)
+                print "Warning: %s does not exist, proceeding without" \
+                      % emb_file
 
     return external_embedding
 
@@ -528,14 +533,14 @@ def get_external_embeddings(options,lang=None,words=None,chars=False):
 def fix_stored_options(stored_opt,options):
 
     stored_opt.predict = True
-    # force langauge embedding needs to be passed to parser!
+    # force language embedding needs to be passed to parser!
     stored_opt.forced_tbank_emb = options.forced_tbank_emb
     stored_opt.ext_emb_dir = options.ext_emb_dir
-    stored_opt.ext_emb_file = options.ext_emb_file
+    stored_opt.ext_word_emb_file = options.ext_word_emb_file
+    stored_opt.ext_char_emb_file = options.ext_char_emb_file
     stored_opt.max_ext_emb = options.max_ext_emb
     stored_opt.shared_task = options.shared_task
     if hasattr(options,'char_map_file'):
         stored_opt.char_map_file = options.char_map_file
     if hasattr(stored_opt,'lang_emb_size'):
         stored_opt.tbank_emb_size = stored_opt.lang_emb_size
-


### PR DESCRIPTION
Replaces the option 'ext-emb-file' with two separate parameters: 'ext-word-emb-file' and 'ext-char-emb-file'. This way, files for both can be specified.